### PR TITLE
Reference old property value from state

### DIFF
--- a/javascript/react-js/inputs-and-lists.md
+++ b/javascript/react-js/inputs-and-lists.md
@@ -268,7 +268,7 @@ class App extends Component {
   onSubmitTask = (e) => {
     e.preventDefault();
     this.setState({
-      tasks: tasks.concat(task),
+      tasks: this.state.tasks.concat(this.state.task),
       task: "",
     });
   };


### PR DESCRIPTION
In the lesson "HANDLE INPUTS AND RENDER LISTS" for React-JS, the final code needs to reference `this.state` when accessing the old value of a property.
